### PR TITLE
Fix compiler errors and ESP32 crash. Add minimumElevation to nextpass.

### DIFF
--- a/src/sgp4ext.cpp
+++ b/src/sgp4ext.cpp
@@ -742,7 +742,8 @@ bool summertime(int year, int month, int day, int hour, int tzHours)
 {
 	if (month<3 || month>10) return false; // keine Sommerzeit in Jan, Feb, Nov, Dez
 	if (month>3 && month<10) return true; // Sommerzeit in Apr, Mai, Jun, Jul, Aug, Sep
-	if (month == 3 && (hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7)) || month == 10 && (hour + 24 * day)<(1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7)))
+	if (((month == 3) && ((hour + 24 * day) >= (1 + tzHours + 24 * (31 - (5 * year / 4 + 4) % 7))))
+      || ((month == 10) && ((hour + 24 * day) < (1 + tzHours + 24 * (31 - (5 * year / 4 + 1) % 7)))))
 		return true;
 	else
 		return false;

--- a/src/sgp4pred.cpp
+++ b/src/sgp4pred.cpp
@@ -112,11 +112,19 @@ double Sgp4::sgp4wrap( double jdCe){
 
 // returns next overpass maximum, starting from a maximum called startpoint
 bool Sgp4::nextpass(passinfo* passdata, int itterations) {
-	Sgp4::nextpass( passdata, itterations, false);
+	return (Sgp4::nextpass( passdata, itterations, false, 0.0));
+}
+
+// returns next overpass. Set direc to false for forward search, true for backwards search
+bool Sgp4::nextpass(passinfo* passdata, int itterations, bool direc) {
+	return (Sgp4::nextpass( passdata, itterations, direc, 0.0));
 }
 
 // returns next overpass maximum, starting from a maximum called startpoint
-bool Sgp4::nextpass( passinfo* passdata, int itterations, bool direc){
+// direc = false for forward search, true for backwards search
+// minimumElevation is the minimum elevation above the horizon in degrees. Passes which are lower than this are rejected
+// returns false if all itterations are below the minimumElevation
+bool Sgp4::nextpass( passinfo* passdata, int itterations, bool direc, double minimumElevation){
 
     double range,jump;
     int i;
@@ -134,7 +142,7 @@ bool Sgp4::nextpass( passinfo* passdata, int itterations, bool direc){
 		jump = 1.0 / revpday;
 	}
 
-    for (i = 0; i < itterations && max_elevation <= 0.0; i++){ //search for elevation aboven zero
+    for (i = 0; i < itterations && max_elevation <= (minimumElevation * pi / 180); i++){ //search for elevation above minimumElevation
        jdCp+= jump;
        max_elevation = - brentmin(jdCp - range , jdCp, jdCp + range, &Sgp4::sgp4wrap , tol, &jdCp, this);
 		#ifdef ESP8266

--- a/src/sgp4pred.h
+++ b/src/sgp4pred.h
@@ -90,8 +90,9 @@ class Sgp4 {
     void findsat(double jdI);     //find satellite position from julian date
     void findsat(unsigned long);  //find satellite position from unix time
 
-    bool nextpass( passinfo* passdata, int); // calculate next overpass data, returns true if succesfull
+    bool nextpass( passinfo* passdata, int itterations); // calculate next overpass data, returns true if succesfull
 	bool nextpass(passinfo* passdata, int itterations, bool direc); //direc = false for forward search, true for backwards search
+    bool nextpass(passinfo* passdata, int itterations, bool direc, double minimumElevation); //minimumElevation = minimum elevation above the horizon (in degrees)
     bool initpredpoint( double juliandate , double startelevation); //initialize prediction algorithm, starting from a juliandate and predict passes aboven startelevation
     bool initpredpoint( unsigned long unix, double startelevation); // from unix time
 

--- a/src/sgp4unit.cpp
+++ b/src/sgp4unit.cpp
@@ -319,11 +319,13 @@ static void dpper
            // nodep used without a trigonometric function ahead
            if ((nodep < 0.0) && (opsmode == 'a'))
                nodep = nodep + twopi;
-           if (fabs(xnoh - nodep) > pi)
+           if ((fabs(xnoh - nodep)) > pi)
+           {
              if (nodep < xnoh)
                 nodep = nodep + twopi;
                else
                 nodep = nodep - twopi;
+           }
            mp    = mp + pl;
            argpp = xls - mp - cosip * nodep;
          }


### PR DESCRIPTION
Hello @Hopperpop ,

I know this library is a few years old, but thank you for sharing it. It is a really nice piece of work!

I had some problems running the code on an ESP32 using Arduino 1.8.13 and esp32 by Espressif Systems (version 2.0.2). The code was crashing when I ran your Sgp4Predictor example. I traced the cause to a missing return statement in the overloaded copy of ```nextpass```. This Pull Request corrects that.

I was also seeing two compiler errors while using a different version of the ESP32 compiler. It was complaining about missing parentheses and code ambiguity. So I fixed those too.

To be able to use this code to predict communication satellite passes, it is useful (actually essential) to be able to set a "minimum elevation" for a successful satellite pass. So I've added ```minimumElevation``` as a parameter for ```nextpass``` and have included an extra overload. The change is backward-compatible, it defaults to 0.0.

I have tested the code on ESP32, SAMD51, nRF52840 (Arduino Nano), Apollo3 (SparkFun Artemis) and STM32F4. It appears to work well on all platforms.

Thank you again for sharing, and I hope you like this Pull Request.

Very best wishes,
Paul
